### PR TITLE
Fix/handle errors

### DIFF
--- a/__tests__/Form/form.test.js
+++ b/__tests__/Form/form.test.js
@@ -84,20 +84,21 @@ describe('Form', () => {
       expect(formResponse.fields).toEqual({})
     })
 
-    test('throws error on form not found', async () => {
+    test('throws rrror on form not found', async () => {
       const form = new Form({apiKey: mockToken})
       form.client = {
         forms: {
           get: jest.fn(() => {
             return {
-              code: 'FORM_NOT_FOUND'
+              code: 'FORM_NOT_FOUND',
+              description: 'form not found'
             }
           })
         }
       }
 
       await expect(form._fetchForm(mockFormId)).rejects.toThrowError(
-        'Form not found, check the provided credentials'
+        'Typeform API returned an error: form not found'
       )
     })
   })

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -14,8 +14,8 @@ module.exports = class Form {
     const form = {}
     const formResult = await this.client.forms.get({uid: formId})
 
-    if (formResult.code && formResult.code === 'FORM_NOT_FOUND') {
-      throw new Error('Form not found, check the provided credentials')
+    if (formResult.code) {
+      throw new Error(`Typeform API returned an error: ${formResult.description}`)
     }
 
     form.id = formResult.id


### PR DESCRIPTION
## Description

Typeform API returns errors in an object with a `code` and a `description`.
Updated the error handling to be generic enough to find it and throw it back to the user.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
