### PR TITLE
feat(short-text):add new field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ The following form fields are currently supported to extract:
 - Yes/No questions (`yes_no`)
 - Opinion scale questions (`opinion_scale`)
 - All variants of multiple choice questions, including an 'other' field, and single vs multiple answers (`multiple_choice`)
-
-## Unsupported fields
-
 - Free text questions (`short_text`)
 
 # Related

--- a/__tests__/Form/__fixtures__/formResponsesResult.json
+++ b/__tests__/Form/__fixtures__/formResponsesResult.json
@@ -73,6 +73,15 @@
                 "Sometimes, we do."
               ]
             }
+          },
+          {
+            "field": {
+              "id": "tCDuMq4dJaIf",
+              "type": "short_text",
+              "ref": "500ea3ea-a37e-46da-aca4-01d294c22fb0"
+            },
+            "type": "text",
+            "text": "Bart"
           }
         ]
     },
@@ -142,6 +151,15 @@
                     "We always do"
                 ]
               }
+            },
+            {
+              "field": {
+                "id": "tCDuMq4dJaIf",
+                "type": "short_text",
+                "ref": "500ea3ea-a37e-46da-aca4-01d294c22fb0"
+              },
+              "type": "text",
+              "text": "Homer"
             }
           ]
       }

--- a/__tests__/Form/__fixtures__/formResponsesResult.json
+++ b/__tests__/Form/__fixtures__/formResponsesResult.json
@@ -57,7 +57,7 @@
             },
             "type": "choice",
             "choice": {
-              "label": "Option 1"
+              "label": "Every couple of years or more"
             }
           },
           {
@@ -127,7 +127,7 @@
               },
               "type": "choice",
               "choice": {
-                "label": "Option 2"
+                "label": "At least once a Month"
               }
             },
             {

--- a/__tests__/Form/__fixtures__/formResult.json
+++ b/__tests__/Form/__fixtures__/formResult.json
@@ -161,6 +161,15 @@
               "required": true
             },
             "type": "multiple_choice"
+          },
+          {
+            "id": "tCDuMq4dJaIf",
+            "title": "Question number 6?",
+            "ref": "500ea3ea-a37e-46da-aca4-01d294c22fb0",
+            "validations": {
+              "required": true
+            },
+            "type": "short_text"
           }
     ],
     "_links": {

--- a/__tests__/Form/__snapshots__/form.test.js.snap
+++ b/__tests__/Form/__snapshots__/form.test.js.snap
@@ -3,6 +3,42 @@
 exports[`Form Fetch Form Responses Form responses full structure is normalized 1`] = `
 Object {
   "fields": Object {
+    "500ea3ea-a37e-46da-aca4-01d294c22fb0": Object {
+      "answers": Object {
+        "Bart": Array [
+          Object {
+            "metadata": Object {
+              "browser": "default",
+              "network_id": "3c3a3176ac",
+              "platform": "other",
+              "referer": "https://example.typeform.com/to/AbCeDeF",
+              "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            },
+            "response_id": "29862c13c9a919816a9c919162",
+            "submitted_at": "2018-10-19T12:56:33Z",
+          },
+        ],
+        "Homer": Array [
+          Object {
+            "metadata": Object {
+              "browser": "default",
+              "network_id": "c13c1ac132",
+              "platform": "other",
+              "referer": "https://example.typeform.com/to/AbCeDeF",
+              "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            },
+            "response_id": "c1c13c1c1c132c213f13",
+            "submitted_at": "2018-10-20T12:41:55Z",
+          },
+        ],
+      },
+      "id": "tCDuMq4dJaIf",
+      "properties": undefined,
+      "ref": "500ea3ea-a37e-46da-aca4-01d294c22fb0",
+      "title": "Question number 6?",
+      "totalRespondents": 2,
+      "type": "short_text",
+    },
     "9a9a9a9c9-a5aa-1c1c-2c2c-c2c1c11c1": Object {
       "answers": Object {
         "Maybe most times we do": Array [],

--- a/__tests__/Form/__snapshots__/form.test.js.snap
+++ b/__tests__/Form/__snapshots__/form.test.js.snap
@@ -83,12 +83,7 @@ Object {
     },
     "ac4ac4a-acac-a5a5-ac4a-ac5ac3ac5a5a": Object {
       "answers": Object {
-        "At least once a Month": Array [],
-        "At least once a Quarter": Array [],
-        "At least once a year": Array [],
-        "Every couple of years or more": Array [],
-        "We don't": Array [],
-        "other": Array [
+        "At least once a Month": Array [
           Object {
             "metadata": Object {
               "browser": "default",
@@ -101,6 +96,22 @@ Object {
             "submitted_at": "2018-10-20T12:41:55Z",
           },
         ],
+        "At least once a Quarter": Array [],
+        "At least once a year": Array [],
+        "Every couple of years or more": Array [
+          Object {
+            "metadata": Object {
+              "browser": "default",
+              "network_id": "3c3a3176ac",
+              "platform": "other",
+              "referer": "https://example.typeform.com/to/AbCeDeF",
+              "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            },
+            "response_id": "29862c13c9a919816a9c919162",
+            "submitted_at": "2018-10-19T12:56:33Z",
+          },
+        ],
+        "We don't": Array [],
       },
       "id": "CtPB5r54ScEN",
       "properties": Object {

--- a/src/Form/Adapters/formFieldsAdapters.js
+++ b/src/Form/Adapters/formFieldsAdapters.js
@@ -34,4 +34,8 @@ formFieldsAnswersAdapters.set('multiple_choice', questionField => {
   return answers
 })
 
+formFieldsAnswersAdapters.set('short_text', questionField => {
+  return {}
+})
+
 module.exports = formFieldsAnswersAdapters

--- a/src/Form/Adapters/formResponsesAnswersAdapters.js
+++ b/src/Form/Adapters/formResponsesAnswersAdapters.js
@@ -79,4 +79,16 @@ formResponseAnswersAdapters.set('multiple_choice', (submission, answer) => {
   }
 })
 
+formResponseAnswersAdapters.set('short_text', (submission, answer) => {
+  const answerSubmission = {
+    response_id: submission.response_id,
+    submitted_at: submission.submitted_at,
+    metadata: submission.metadata
+  }
+  return {
+    answerLabel: answer.text,
+    answerData: answerSubmission
+  }
+})
+
 module.exports = formResponseAnswersAdapters

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -28,7 +28,7 @@ module.exports = class Form {
   }
 
   _getFormQuestions(form) {
-    const formTypesWhitelist = ['yes_no', 'opinion_scale', 'multiple_choice']
+    const formTypesWhitelist = ['yes_no', 'opinion_scale', 'multiple_choice', 'short_text']
     let formQuestions = {}
 
     formQuestions = form.fields
@@ -132,6 +132,10 @@ module.exports = class Form {
               })
             } else if (typeof adaptorResponse === 'object') {
               let {answerLabel, answerData} = adaptorResponse
+
+              if (form.fields[fieldReference].answers[answerLabel] === undefined) {
+                form.fields[fieldReference].answers[answerLabel] = []
+              }
 
               const newAnswersList = form.fields[fieldReference].answers[answerLabel].concat(
                 answerData

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -133,11 +133,6 @@ module.exports = class Form {
             } else if (typeof adaptorResponse === 'object') {
               let {answerLabel, answerData} = adaptorResponse
 
-              if (form.fields[fieldReference].answers[answerLabel] === undefined) {
-                answerLabel = 'other'
-                form.fields[fieldReference].answers[answerLabel] = []
-              }
-
               const newAnswersList = form.fields[fieldReference].answers[answerLabel].concat(
                 answerData
               )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added short-text type of question. It is open-ended question.

Updated fetchFormResponses and added this type in whitelist in form.js
added short-text in adapters
updated snapshot to this update

Fixed formResponsesResult.json before adding short-text because there was inaccuracy and it made conflict with short-text in testing. Question 4 doesn't has  'option 1' and 'option 2 in list allowed answers and  can't   has  other choice other than expected.

Also update Readme.  Moved short_text from unsupported to supported. 

It works with typeform-export-excel

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#8 

## Motivation and Context

Extends the number of types of questions

## How Has This Been Tested?

Data from typeform and snapshot 

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun 
