### PR TITLE
fix(opinion-scale): bug with number of options

### DIFF
--- a/__tests__/Form/__snapshots__/form.test.js.snap
+++ b/__tests__/Form/__snapshots__/form.test.js.snap
@@ -261,7 +261,6 @@ Object {
         "0": Array [],
         "1": Array [],
         "10": Array [],
-        "11": Array [],
         "2": Array [],
         "3": Array [],
         "4": Array [],

--- a/src/Form/Adapters/formFieldsAdapters.js
+++ b/src/Form/Adapters/formFieldsAdapters.js
@@ -10,10 +10,10 @@ formFieldsAnswersAdapters.set('yes_no', () => {
 
 formFieldsAnswersAdapters.set('opinion_scale', questionField => {
   const countStart = questionField.properties.start_at_one ? 1 : 0
-  const countFinish = questionField.properties.steps
+  const countFinish = questionField.properties.steps + countStart
 
   const scaleOptions = {}
-  for (let i = countStart; i <= countFinish; i++) {
+  for (let i = countStart; i < countFinish; i++) {
     scaleOptions[i] = []
   }
 


### PR DESCRIPTION
## Description

Fixed bug with filling one option more if option-scale starts from zero.
Removed incorrect option in snapshot.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#9 

## Motivation and Context

for correct formation opinion-scale

## How Has This Been Tested?

Data from typeform, snapshot.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
