### PR TITLE
feat(opinion_scale): add average and median stats

### DIFF
--- a/__tests__/Form/__snapshots__/form.test.js.snap
+++ b/__tests__/Form/__snapshots__/form.test.js.snap
@@ -295,7 +295,9 @@ Object {
           },
         ],
       },
+      "average": 7,
       "id": "TIOUqoiyBSi81",
+      "median": 7,
       "properties": Object {
         "labels": Object {
           "left": "Not knowledgeable",

--- a/__tests__/Form/adapters.test.js
+++ b/__tests__/Form/adapters.test.js
@@ -3,6 +3,9 @@ const formResponseAnswersAdapters = require(path.resolve(
   './src/Form/Adapters/formResponsesAnswersAdapters'
 ))
 const formFieldsAdapters = require(path.resolve('./src/Form/Adapters/formFieldsAdapters'))
+const questionStatisticsAdapters = require(path.resolve(
+  './src/Form/Adapters/questionStatisticsAdapters'
+))
 
 describe('Adapters', () => {
   describe('Forms fields', () => {
@@ -41,6 +44,37 @@ describe('Adapters', () => {
 
       expect(answerObject).toHaveProperty('answerLabel', 'other')
       expect(answerObject).toHaveProperty('answerData.data', mockAnswer.choice.other)
+    })
+  })
+
+  describe('Fields statistics', () => {
+    it('Opinion scale calculates correct median and average', () => {
+      const mockQuestion1 = {
+        1: Array(6),
+        2: Array(4),
+        3: Array(2),
+        4: Array(9)
+      }
+
+      const mockQuestion2 = {
+        1: Array(6),
+        2: Array(12),
+        3: Array(3),
+        4: Array(6)
+      }
+
+      const questionStatisticAdapter = questionStatisticsAdapters.get('opinion_scale')
+      const adaptorResponse1 = questionStatisticAdapter(mockQuestion1)
+      const adaptorResponse2 = questionStatisticAdapter(mockQuestion2)
+
+      expect(adaptorResponse1).toMatchObject({
+        median: 3,
+        average: 2.67
+      })
+      expect(adaptorResponse2).toMatchObject({
+        median: 2,
+        average: 2.33
+      })
     })
   })
 })

--- a/src/Form/Adapters/questionStatisticsAdapters.js
+++ b/src/Form/Adapters/questionStatisticsAdapters.js
@@ -1,0 +1,24 @@
+'use strict'
+const mathUtils = require('../Utils/MathUtils')
+
+const questionStatisticsAdapters = new Map()
+questionStatisticsAdapters.set('opinion_scale', answers => {
+  const answersArr = Object.keys(answers).reduce((result, key) => {
+    const amount = answers[key].length
+    if (amount) {
+      const number = parseInt(key)
+      result = result.concat(Array(amount).fill(number))
+    }
+    return result
+  }, [])
+
+  const median = mathUtils.median(answersArr)
+  const average = mathUtils.average(answersArr)
+
+  return {
+    median,
+    average: mathUtils.roundTo(average, 2)
+  }
+})
+
+module.exports = questionStatisticsAdapters

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -3,6 +3,7 @@
 const {createClient} = require('@typeform/api-client')
 const formFieldAdapters = require('./Adapters/formFieldsAdapters')
 const formResponseAnswersAdapters = require('./Adapters/formResponsesAnswersAdapters')
+const questionStatisticsAdapters = require('./Adapters/questionStatisticsAdapters')
 
 module.exports = class Form {
   constructor({apiKey} = {}) {
@@ -101,6 +102,17 @@ module.exports = class Form {
     }
   }
 
+  _fillStatistics(form) {
+    const fields = Object.values(form.fields)
+    for (const field of fields) {
+      const questionStatisticAdapter = questionStatisticsAdapters.get(field.type)
+      if (questionStatisticAdapter) {
+        const adaptorResponse = questionStatisticAdapter(field.answers)
+        Object.assign(field, adaptorResponse)
+      }
+    }
+  }
+
   async fetchFormResponses(formId) {
     const form = await this._fetchForm(formId)
     const {totalRespondents, submissionAnswers} = await this._fetchResponses(formId)
@@ -146,6 +158,7 @@ module.exports = class Form {
           }
         })
     })
+    this._fillStatistics(form)
 
     return form
   }

--- a/src/Form/Utils/MathUtils.js
+++ b/src/Form/Utils/MathUtils.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const median = arr => {
+  const mid = Math.floor(arr.length / 2)
+  const nums = [...arr].sort()
+  return arr.length % 2 !== 0 ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2
+}
+const average = arr => arr.reduce((sum, current) => sum + current, 0) / arr.length
+
+const roundTo = (number, precision) => Number(number.toFixed(precision))
+
+module.exports = {
+  median,
+  average,
+  roundTo
+}


### PR DESCRIPTION


## Description

Added average and median stats to opinion_scale.
Added questionStatisticsAdapter.
Added test for opinion_scale average and median.
Updated snapshot to this change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#10 

## Motivation and Context

Simplifies understanding of question results

## How Has This Been Tested?

Data from typeform, snapshot and test in adapter.test.js

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [xI have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
