### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
       <a href="https://www.npmjs.org/package/@lirantal/typeform-client"><img src="https://badgen.net/npm/dt/@lirantal/typeform-client" alt="downloads"/></a>
       <a href="https://travis-ci.org/lirantal/typeform-client"><img src="https://badgen.net/travis/lirantal/typeform-client" alt="build"/></a>
       <a href="https://codecov.io/gh/lirantal/typeform-client"><img src="https://badgen.net/codecov/c/github/lirantal/typeform-client" alt="codecov"/></a>
-      <a href="https://snyk.io/test/github/lirantal/typeform-client"><img src="https://snyk.io/test/github/lirantal/typeform-client/badge.svg" alt="known vulnerabilities"/></a>
       <a href="https://github.com/semantic-release/semantic-release"><img src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat" alt="semantic-release"/></a>
       <a href="https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Security Responsible Disclosure"/></a>
 </p>


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.